### PR TITLE
Adds option to make groups collapsible

### DIFF
--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
@@ -178,7 +178,7 @@
                 $scope.groupSeparators[tab.label] = [];
 
                 tab.properties.map(function(prop, i) {
-                    if (i > 0 && prop.editor == "Our.Umbraco.Matryoshka.GroupSeparator") {
+                    if (i > 0 && prop.editor == "Our.Umbraco.Matryoshka.GroupSeparator" && prop.config.anchor == "1") {
                         $scope.groupSeparators[tab.label].push(prop);
                     }
                 });

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.css
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.css
@@ -65,3 +65,40 @@
     border-bottom: 0;
     background-image:linear-gradient(to bottom, #fdfcfc, #faf9f9);
 }
+
+.our-matryoshka-group-separator--collapsed:not(.our-matryoshka-group-separator-container) {
+    display:none;
+}
+
+.our-matryoshka-group-separator-container.our-matryoshka-group-separator--collapsed .umb-control-group {
+    margin-bottom:0;
+}
+
+.our-matryoshka-group-separator-container.our-matryoshka-group-separator--collapsed .umb-control-group:after {
+    display:none;
+}
+
+.our-matryoshka-group-separator-collapser {
+    color:#1b264f;
+    float:right;
+    margin-right:20px;
+    margin-top:10px;
+    border-color:#e9e9eb !important;
+}
+
+.our-matryoshka-group-separator-collapser:hover,
+.our-matryoshka-group-separator-collapser:focus {
+    outline:none;
+    color:#2152a3;
+    background:#faf9f9;
+}
+
+.our-matryoshka-group-separator-container.our-matryoshka-group-separator--collapsed .our-matryoshka-group-separator-collapser--expanded,
+.our-matryoshka-group-separator-container:not(.our-matryoshka-group-separator--collapsed) .our-matryoshka-group-separator-collapser--collapsed {
+    display:none;
+}
+
+.our-matryoshka-group-separator-container:not(.our-matryoshka-group-separator--collapsed) .our-matryoshka-group-separator-collapser--expanded,
+.our-matryoshka-group-separator-container.our-matryoshka-group-separator--collapsed .our-matryoshka-group-separator-collapser--collapsed {
+    display:block;
+}

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html
@@ -1,4 +1,14 @@
-﻿<div class="our-matryoshka-group-separator" id="our-matryoshka-group-separator-{{ model.alias }}">
+﻿<div ng-controller="Matryoshka.GroupSeparator.Controller" class="our-matryoshka-group-separator" id="our-matryoshka-group-separator-{{ model.alias }}">
+    <button class="btn-reset btn-outline btn-small our-matryoshka-group-separator-collapser" type="button" ng-click="toggleCollapse()" ng-if="collapsible">
+        <span class="our-matryoshka-group-separator-collapser--collapsed">
+            Expand
+            <i class="icon-navigation-down "></i>
+        </span>
+        <span class="our-matryoshka-group-separator-collapser--expanded">
+            Collapse
+            <i class="icon-navigation-up"></i>
+        </span>
+    </button>
     <label>
         {{ model.label }}
         <small ng-bind-html="model.description | preserveNewLineInHtml"></small>

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
@@ -1,0 +1,28 @@
+angular.module("umbraco").controller("Matryoshka.GroupSeparator.Controller", [
+
+    "$scope",
+    "$rootScope",
+    "$timeout",
+    "$element",
+
+    function ($scope, $rootScope, $timeout, $element) {
+        console.log($element);
+        $timeout(function() {
+            $element.closest(".umb-property").addClass("our-matryoshka-group-separator-container");
+        });
+
+        $scope.toggleCollapse = function() {
+            $timeout(function() {
+                var separator = $element.closest(".umb-property");
+                separator.toggleClass("our-matryoshka-group-separator--collapsed");
+
+                separator.nextUntil(".our-matryoshka-group-separator-container").toggleClass("our-matryoshka-group-separator--collapsed");
+            });
+        }
+
+        if ($scope.model.config.collapsedByDefault) {
+            $scope.toggleCollapse();
+        }
+
+    }
+]);

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
@@ -1,21 +1,23 @@
 angular.module("umbraco").controller("Matryoshka.GroupSeparator.Controller", [
 
     "$scope",
-    "$rootScope",
     "$timeout",
     "$element",
 
-    function ($scope, $rootScope, $timeout, $element) {
-        console.log($element);
+    function ($scope, $timeout, $element) {
+
+        var separator = $element.closest(".umb-nested-content-property-container");
+        if (separator.length == 0) {
+            separator = $element.closest(".umb-property");
+        }
+        
         $timeout(function() {
-            $element.closest(".umb-property").addClass("our-matryoshka-group-separator-container");
+            separator.addClass("our-matryoshka-group-separator-container");
         });
 
         $scope.toggleCollapse = function() {
             $timeout(function() {
-                var separator = $element.closest(".umb-property");
                 separator.toggleClass("our-matryoshka-group-separator--collapsed");
-
                 separator.nextUntil(".our-matryoshka-group-separator-container").toggleClass("our-matryoshka-group-separator--collapsed");
             });
         }

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js
@@ -3,8 +3,10 @@ angular.module("umbraco").controller("Matryoshka.GroupSeparator.Controller", [
     "$scope",
     "$timeout",
     "$element",
+    "editorState",
 
-    function ($scope, $timeout, $element) {
+    function ($scope, $timeout, $element, editorState) {
+        var isNew = editorState.getCurrent().id == 0;
 
         var separator = $element.closest(".umb-nested-content-property-container");
         if (separator.length == 0) {
@@ -22,7 +24,9 @@ angular.module("umbraco").controller("Matryoshka.GroupSeparator.Controller", [
             });
         }
 
-        if ($scope.model.config.collapsedByDefault) {
+        $scope.collapsible = $scope.model.config.collapsible.indexOf("collapsible") == 0;
+
+        if (($scope.model.config.collapsible == "collapsibleOpenOnCreation" && !isNew) || $scope.model.config.collapsible == "collapsibleClosedOnLoad") {
             $scope.toggleCollapse();
         }
 

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/package.manifest
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/package.manifest
@@ -7,10 +7,27 @@
             view: "~/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html",
             hideLabel: true
         },
+        prevalues: {
+            fields: [
+                {
+                    label: "Collapsible",
+                    description: "Should groups starting with this separator be collapsible?",
+                    key: "collapsible",
+                    view: "boolean"
+                },
+                {
+                    label: "Collapsed by default",
+                    description: "Should groups starting with this separator be collapsed by default? Checking this, will also make groups collapsible!",
+                    key: "collapsedByDefault",
+                    view: "boolean"
+                },
+            ]
+        },
 		icon: "icon-matryoshka"
   	}],
     javascript: [
         "~/App_Plugins/Our.Umbraco.Matryoshka/content-interceptor.js",
+        "~/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js",
         "~/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js",
         "~/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-val-tab.directive.js"
       ],

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/package.manifest
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/package.manifest
@@ -1,37 +1,46 @@
 ﻿{
-    propertyEditors: [
+    "$schema" : "http://json.schemastore.org/package.manifest",
+    "propertyEditors": [
     {
-        alias: "Our.Umbraco.Matryoshka.GroupSeparator",
-        name: "Matryoshka Group Separator",
-        editor: {
-            view: "~/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html",
-            hideLabel: true
+        "alias": "Our.Umbraco.Matryoshka.GroupSeparator",
+        "name": "Matryoshka Group Separator",
+        "editor": {
+            "view": "~/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html",
+            "hideLabel": true
         },
-        prevalues: {
-            fields: [
+        "prevalues": {
+            "fields": [
                 {
-                    label: "Collapsible",
-                    description: "Should groups starting with this separator be collapsible?",
-                    key: "collapsible",
-                    view: "boolean"
-                },
+                    "label": "Show as anchor",
+                    "description": "Should groups starting with this separator be shown as an anchor in a dropdown menu from its tab?",
+                    "key": "anchor",
+                    "view": "boolean"
+                },                
                 {
-                    label: "Collapsed by default",
-                    description: "Should groups starting with this separator be collapsed by default? Checking this, will also make groups collapsible!",
-                    key: "collapsedByDefault",
-                    view: "boolean"
-                },
+                    "label": "Collapsible",
+                    "description": "Should this group be collapsible? And what default state should they have?",
+                    "key": "collapsible",
+                    "view": "radiobuttonlist",
+                    "config": {
+                        "prevalues": [
+                            { "value": "fixed", "label": "Fixed" },
+                            { "value": "collapsibleOpenOnLoad", "label": "Collapsible, open on load" },
+                            { "value": "collapsibleClosedOnLoad", "label": "Collapsible, closed on load" },
+                            { "value": "collapsibleOpenOnCreation", "label": "Collapsible, open on creation, closed on edit" }
+                        ]
+                    }
+                }
             ]
         },
-		icon: "icon-matryoshka"
+		"icon": "icon-umb-contour"
   	}],
-    javascript: [
+    "javascript": [
         "~/App_Plugins/Our.Umbraco.Matryoshka/content-interceptor.js",
         "~/App_Plugins/Our.Umbraco.Matryoshka/groupseparator.controller.js",
         "~/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js",
         "~/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-val-tab.directive.js"
       ],
-    css: [
+    "css": [
         "~/App_Plugins/Our.Umbraco.Matryoshka/group-separator.css",
         "~/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css"
     ]


### PR DESCRIPTION
Fixes #3 

I got this working with some Jquery trickery. You can see it in action in this gif:
![T9j2RgWhRt](https://user-images.githubusercontent.com/3726467/80402760-b03a5c80-88be-11ea-8ce5-51463bea7edd.gif)

The group separator property editor is extended with two new options. One for setting a group to be able to collapse, and one the set it as collapsed by default.

![chrome_99FBdKHEFh](https://user-images.githubusercontent.com/3726467/80402787-c34d2c80-88be-11ea-92f8-da9b264e670c.png)

What do you guys think? Would this be useful?