### PR TITLE
Scroll to groups

### DIFF
--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
@@ -121,24 +121,37 @@
             scrollableNode.addEventListener('mousewheel', cancelScrollTween);
 
             function getScrollPositionFor(tab, alias) {
-                var previousTab = $scope.currentTab + "";
-                $scope.currentTab = tab;
+                var offset = null;
+                var groupSeparator = null;
 
-                var groupSeparator = document.querySelector("#our-matryoshka-group-separator-" + alias);
+                if (alias == 0) {
+                    offset = 0;
+                } else {
+                    var previousTab = $scope.currentTab + "";
+                    $scope.currentTab = tab;
 
-                if (!groupSeparator) { 
-                    $scope.currentTab = previousTab;
-                    return null; 
+                    groupSeparator = document.querySelector("#our-matryoshka-group-separator-" + alias);
+
+                    if (!groupSeparator) {
+                        $scope.currentTab = previousTab;
+                        offset = null;
+                    }
                 }
 
-                return groupSeparator.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement.offsetTop - 40;
+                return $timeout(function () {
+                    if (groupSeparator) {
+                        offset = groupSeparator.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement.offsetTop - 40;
+                    }
+
+                    return offset;
+                });
             }
 
             $scope.scrollTo = function(tab, alias) {
-                $timeout(function() {
-                    var y = alias != 0 ? getScrollPositionFor(tab, alias) : 0;
+                getScrollPositionFor(tab, alias).then(function(response) {
+                    var y = response;
 
-                    if (alias === 0 || getScrollPositionFor !== null) {
+                    if (alias === 0 || y !== null) {
                         var viewportHeight = scrollableNode.clientHeight;
                         var from = scrollableNode.scrollTop;
                         var to = Math.min(y, scrollableNode.scrollHeight - viewportHeight);

--- a/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html
+++ b/src/UI/App_Plugins/Our.Umbraco.Matryoshka/group-separator.html
@@ -1,4 +1,4 @@
-﻿<div class="our-matryoshka-group-separator">
+﻿<div class="our-matryoshka-group-separator" id="our-matryoshka-group-separator-{{ model.alias }}">
     <label>
         {{ model.label }}
         <small ng-bind-html="model.description | preserveNewLineInHtml"></small>


### PR DESCRIPTION
Added a missing id to the groups so they can be found by id.
Also, made the actual scroll perform after a timeout promise, so it gets the right offset of the tab group after the cycle has completed and the group is visible in the DOM.